### PR TITLE
More backticks in diff block in Markdown

### DIFF
--- a/src/log-text.ts
+++ b/src/log-text.ts
@@ -49,9 +49,9 @@ export function getLogText(result: ExecuteResult, command: Command): string {
   }
   logText = logText + "\n";
   if (configuration.isCI) {
-    logText = logText + "```diff\n";
+    logText = logText + "````diff\n";
     logText = logText + result.diffString;
-    logText = logText + "\n```";
+    logText = logText + "\n````";
   } else {
     logText = logText + result.diffString;
     logText = logText + "\n\n========= End of Result =========\n";


### PR DESCRIPTION
A naive attempt to prevent this:
![image](https://user-images.githubusercontent.com/94334/107165976-53c3ac00-69bd-11eb-97e2-7dfb90fcda30.png)

